### PR TITLE
made it so that connectionString looks at relative path

### DIFF
--- a/AutomatedTests/App.config
+++ b/AutomatedTests/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <connectionStrings>
     <add name="ListDatabase"
-         connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=C:\Users\justi\Desktop\TMJ_TP\TMJ_TP\CustomList\ListDatabase.mdf;Integrated Security=True"
+         connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\ListDatabase.mdf;Integrated Security=True"
 	 providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <startup>

--- a/CustomList/App.config
+++ b/CustomList/App.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <connectionStrings>
-    <add name="ListDatabase" 
-         connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=C:\Users\justi\Desktop\TMJ_TP\TMJ_TP\CustomList\ListDatabase.mdf;Integrated Security=True"
+    <add name="ListDatabase"
+         connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\ListDatabase.mdf;Integrated Security=True"
 	 providerName="System.Data.SqlClient"/>
   </connectionStrings>
     <startup> 

--- a/CustomList/DatabaseClass.cs
+++ b/CustomList/DatabaseClass.cs
@@ -13,7 +13,10 @@ namespace CustomList
     {
         public static string ConnectionVal()
         {
-            
+            string executable = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string path = (System.IO.Path.GetDirectoryName(executable));
+            AppDomain.CurrentDomain.SetData("DataDirectory", path);
+
             return ConfigurationManager.ConnectionStrings["ListDatabase"].ConnectionString;
         }
         public static string connectionLine = ConnectionVal();


### PR DESCRIPTION
this means that there's no longer a need to manually change the connectionString each time the project is cloned on a different machine