### PR TITLE
Entry name centering fix

### DIFF
--- a/CustomList/EntryComponent.cs
+++ b/CustomList/EntryComponent.cs
@@ -134,14 +134,15 @@ namespace CustomList
             btnDots.MouseClick += new System.Windows.Forms.MouseEventHandler(btnDotsClicked);
 
             //entry name
-            lblEntryName.AutoSize = true;
-            lblEntryName.Font = new System.Drawing.Font("Nirmala UI", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            lblEntryName.Dock = DockStyle.Fill;
+            lblEntryName.Font = new System.Drawing.Font("Nirmala UI", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
             lblEntryName.ForeColor = System.Drawing.Color.FromArgb(0, 126, 249);
-            lblEntryName.Location = new System.Drawing.Point(0, 2);
             lblEntryName.Name = "lblEntryName" + index;
-            lblEntryName.Size = new System.Drawing.Size(69, 23);
             lblEntryName.Text = entry.name;
             lblEntryName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            //workaround for Label's inability to center text/change line spacing
+            if (entry.name.Length > 16)
+                lblEntryName.Text = entry.name.Substring(0, 14) + "..";
 
             watchCountPanel.Controls.Add(lblWatchCount);
             watchCountPanel.Dock = System.Windows.Forms.DockStyle.Left;


### PR DESCRIPTION
Tried a couple of fixes.
1. If title is longer than 16 chars then insert a newline and the title will break into two lines - fitting into the component
2. Autosize messes everything up and there's no more centering
3. Tried to leave it that the title just splits off when long, but then for some reason it loses centering
Came up with a workaround - if longer than 16 chars then take substring and add ".." to indicate it's shortened. The user will still be able to see the full title when "MoreInfo" is opened
![Capture](https://user-images.githubusercontent.com/78436416/116611179-bbdfb980-a93e-11eb-887a-a2da2dc76841.PNG)
